### PR TITLE
Adding headless options for the maxscale and statestore

### DIFF
--- a/mariadb-enterprise/catalog/maxscale.yaml
+++ b/mariadb-enterprise/catalog/maxscale.yaml
@@ -24,6 +24,9 @@ spec:
   - name: maxscale-readonly
     port: {{ .Values.mariadb.maxscale.ports.readonly }}
     targetPort: {{ .Values.mariadb.maxscale.ports.readonly }}
+  {{- if .Values.mariadb.maxscale.headless }}
+  clusterIP: None
+  {{- end }}
   selector:
     maxscale.mariadb: {{ .Release.Name }}
 ---

--- a/mariadb-enterprise/catalog/state-store.yaml
+++ b/mariadb-enterprise/catalog/state-store.yaml
@@ -20,6 +20,9 @@ metadata:
     id.mariadb: "{{ .Values.mariadb.cluster.id }}"
     {{ end }}
 spec:
+  {{- if .Values.mariadb.maxscale.headless }}
+  clusterIP: None
+  {{- end }}
   selector:
     state-store.mariadb: {{ .Release.Name }}
   ports:

--- a/mariadb-enterprise/values.yaml
+++ b/mariadb-enterprise/values.yaml
@@ -52,7 +52,9 @@ mariadb:
       limits:
         cpu: null     # e.g. "3000m"
         memory: null  # e.g. "9G"
+    headless: false
 
 # statestore parameters
   statestore:
     image: mariadb/statestore:0.0.3
+    headless: false


### PR DESCRIPTION
This should allow us to use headless options. E.g.:
>helm install . --name mariadb -f values.yaml --set mariadb.maxscale.headless=true --set mariadb.statestore.headless=true

Should result in:
```shell
$ kubectl get svc
NAME                    TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)             AGE
mariadb-mariadb     ClusterIP   None         <none>        4006/TCP,4008/TCP   5m
mariadb-mdb-clust   ClusterIP   None         <none>        3306/TCP            5m
mariadb-mdb-state   ClusterIP   None         <none>        80/TCP              5m
```

Then we can use the service/FQDN:
```shell
$ mysql -urepl -P4006 -p -h mariadb-mariadb.mariadb.svc.sol1.diamanti.com
Enter password:
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 5
Server version: 10.3.12-MariaDB-1:10.3.12+maria~bionic-log mariadb.org binary distribution
```

Signed-off-by: William Mowery <william@diamanti.com>